### PR TITLE
UPDATED composer.json to include ubc as the identifier for the CLF

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,6 @@
     "require"    : {
         "composer/installers": "~1.0",
         "ubc/full-width-clf": "*",
-        "wp-hybrid-clf" : "*"
+        "ubc/wp-hybrid-clf" : "*"
     }
 }


### PR DESCRIPTION
In require you have wp-hybrid-clf - as this theme isn't on the main composer repository, we'll need an identifier - we have ubc/wp-hybrid-clf within our SATIS install which means that we can install it locally.
